### PR TITLE
Add script to download the latest version

### DIFF
--- a/.buildscript/get-latest-version.sh
+++ b/.buildscript/get-latest-version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Usage: get-latest-version.sh [executable_name]
+# Download the latest release, for the given executable (default to "tester_linux_amd64")
+
+executable=$1
+
+if [[ -z ${executable} ]] ; then
+    executable="tester_linux_amd64"
+fi
+
+latest=$(git tag | tail -1)
+
+wget https://github.com/segmentio/library-e2e-tester/releases/download/${latest}/${executable}


### PR DESCRIPTION
Provide a script to download the latest version. Libraries that use this harness only need to call this script without knowing explicitly what the latest version is. See https://github.com/segmentio/analytics-java/pull/134 for an example.