### PR TITLE
Update e2e test harness to use for Roku acceptance testing

### DIFF
--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"time"
 
@@ -11,6 +12,16 @@ import (
 
 	_ "github.com/segmentio/events/text"
 )
+
+/* print content of test result file on stdout */
+func printTestResults(resultFile string) {
+	fmt.Println("Test result file: ", resultFile)
+	testResults, err := ioutil.ReadFile(resultFile) // just pass the file name
+	if err != nil {
+		events.Log("error print results: %{error}v", err)
+	}
+	fmt.Println(string(testResults))
+}
 
 func main() {
 	var config struct {
@@ -49,7 +60,7 @@ func main() {
 	}
 
 	err := t.Test(invoker)
-	events.Log("Test result file: %v", config.TestResultFile)
+	printTestResults(config.TestResultFile)
 	if err != nil {
 		events.Log("test error: %{error}v", err)
 		os.Exit(1)

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/segmentio/conf"
 	"github.com/segmentio/events"
@@ -22,6 +24,12 @@ func main() {
 	}
 	conf.Load(&config)
 
+	// if TestResultFile is not specified, default to
+	// test-results-YYYY-MM-DDTHH:MM:SS.txt (with current time value)
+	if config.TestResultFile == "" {
+		config.TestResultFile = fmt.Sprintf("test-results-%v.txt", time.Now().Format("2006-01-02T15:04:05"))
+	}
+
 	invoker := tester.NewCLIInvoker(config.Path)
 
 	t := &tester.T{
@@ -41,6 +49,7 @@ func main() {
 	}
 
 	err := t.Test(invoker)
+	events.Log("Test result file: %v", config.TestResultFile)
 	if err != nil {
 		events.Log("test error: %{error}v", err)
 		os.Exit(1)

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -16,6 +16,8 @@ func main() {
 		SegmentWriteKey     string `conf:"segment-write-key"        help:"writekey for the Segment project to send data to" validate:"nonzero"`
 		WebhookBucket       string `conf:"webhook-bucket"           help:"webhook bucket the Segment project sends data to" validate:"nonzero"`
 		WebhookAuthUsername string `conf:"webhook-auth-username"    help:"basic auth username for the webhook bucket the Segment project sends data to" validate:"nonzero"`
+		TestAllFixtures     bool   `conf:"test-all-fixtures"        help:"test all fixtures, regardless of individual failures"`
+		TestResultFile      string `conf:"test-result-file"         help:"File name to write test results"`
 		Debug               bool   `conf:"debug"                    help:"Enable Debugging"`
 	}
 	conf.Load(&config)
@@ -26,6 +28,8 @@ func main() {
 		SegmentWriteKey:     config.SegmentWriteKey,
 		WebhookBucket:       config.WebhookBucket,
 		WebhookAuthUsername: config.WebhookAuthUsername,
+		ReportFileName:      config.TestResultFile,
+		TestAllFixtures:     config.TestAllFixtures,
 	}
 
 	if config.Debug {

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -18,7 +18,7 @@ func main() {
 		SegmentWriteKey     string `conf:"segment-write-key"        help:"writekey for the Segment project to send data to" validate:"nonzero"`
 		WebhookBucket       string `conf:"webhook-bucket"           help:"webhook bucket the Segment project sends data to" validate:"nonzero"`
 		WebhookAuthUsername string `conf:"webhook-auth-username"    help:"basic auth username for the webhook bucket the Segment project sends data to" validate:"nonzero"`
-		TestAllFixtures     bool   `conf:"test-all-fixtures"        help:"test all fixtures, regardless of individual failures"`
+		FailFast            bool   `conf:"failfast"                 help:"disable running additional tests after any test fails"`
 		TestResultFile      string `conf:"test-result-file"         help:"File name to write test results"`
 		Debug               bool   `conf:"debug"                    help:"Enable Debugging"`
 	}
@@ -37,7 +37,7 @@ func main() {
 		WebhookBucket:       config.WebhookBucket,
 		WebhookAuthUsername: config.WebhookAuthUsername,
 		ReportFileName:      config.TestResultFile,
-		TestAllFixtures:     config.TestAllFixtures,
+		FailFast:            config.FailFast,
 	}
 
 	if config.Debug {

--- a/tester.go
+++ b/tester.go
@@ -30,7 +30,7 @@ type T struct {
 	WebhookBucket       string
 	WebhookAuthUsername string
 	ReportFileName      string
-	TestAllFixtures     bool // if true, test all fixtures regardless of individual results
+	FailFast            bool // disable running additional tests after any test fails
 }
 
 // Test invokes the test binaries.
@@ -71,7 +71,7 @@ func (t *T) Test(invoker Invoker) error {
 			f, err := Asset("fixtures/" + dir + "/" + fixture)
 			if err != nil {
 				testrun.Error("could not read fixture " + fixture)
-				if !t.TestAllFixtures {
+				if t.FailFast {
 					return errors.Wrap(err, "could not read fixture "+fixture)
 				}
 				res = err
@@ -80,7 +80,7 @@ func (t *T) Test(invoker Invoker) error {
 			var buf bytes.Buffer
 			if err := producer.Produce(ctx, bytes.NewReader(f), &buf); err != nil {
 				testrun.Error(fixture + ": could not produce messages")
-				if !t.TestAllFixtures {
+				if t.FailFast {
 					return errors.Wrap(err, fixture+": could not produce messages")
 				}
 				res = err
@@ -89,7 +89,7 @@ func (t *T) Test(invoker Invoker) error {
 			var msg map[string]interface{}
 			if err := json.Unmarshal(buf.Bytes(), &msg); err != nil {
 				testrun.Error(fixture + ": could not parse json")
-				if !t.TestAllFixtures {
+				if t.FailFast {
 					return errors.Wrap(err, fixture+": could not parse json")
 				}
 				res = err
@@ -121,7 +121,7 @@ func (t *T) Test(invoker Invoker) error {
 				properties, err := json.Marshal(msg["properties"])
 				if err != nil {
 					testrun.Error("could not marshal properties")
-					if !t.TestAllFixtures {
+					if t.FailFast {
 						return errors.Wrap(err, "could not marshal properties")
 					}
 					res = err
@@ -133,7 +133,7 @@ func (t *T) Test(invoker Invoker) error {
 				properties, err := json.Marshal(msg["properties"])
 				if err != nil {
 					testrun.Error("could not marshal properties")
-					if !t.TestAllFixtures {
+					if t.FailFast {
 						return errors.Wrap(err, "could not marshal properties")
 					}
 					res = err
@@ -143,7 +143,7 @@ func (t *T) Test(invoker Invoker) error {
 				traits, err := json.Marshal(msg["traits"])
 				if err != nil {
 					testrun.Error("could not marshal traits")
-					if !t.TestAllFixtures {
+					if t.FailFast {
 						return errors.Wrap(err, "could not marshal traits")
 					}
 					res = err
@@ -153,7 +153,7 @@ func (t *T) Test(invoker Invoker) error {
 				traits, err := json.Marshal(msg["traits"])
 				if err != nil {
 					testrun.Error("could not marshal traits")
-					if !t.TestAllFixtures {
+					if t.FailFast {
 						return errors.Wrap(err, "could not marshal traits")
 					}
 					res = err
@@ -169,7 +169,7 @@ func (t *T) Test(invoker Invoker) error {
 
 			if err := invoker(ctx, args...); err != nil {
 				testrun.Error("could not invoke command")
-				if !t.TestAllFixtures {
+				if t.FailFast {
 					return errors.Wrap(err, "could not invoke command")
 				}
 				res = err
@@ -180,7 +180,7 @@ func (t *T) Test(invoker Invoker) error {
 			if err := t.testMessage(msg); err != nil {
 				testrun.Fail(err.Error())
 				testrun.AddDetails(string(buf.Bytes()))
-				if !t.TestAllFixtures {
+				if t.FailFast {
 					return err
 				}
 				res = err

--- a/testrun.go
+++ b/testrun.go
@@ -1,0 +1,54 @@
+package tester
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+/* Data structure to record information about a test run (execution of a test case) */
+type TestRun struct {
+	TestCaseName string
+	StartTime    time.Time
+	EndTime      time.Time
+	Result       string
+	Details      string
+}
+
+func (tr *TestRun) Start(testcase string) {
+	tr.TestCaseName = testcase
+	tr.StartTime = time.Now()
+}
+
+func (tr *TestRun) End(result string) {
+	tr.EndTime = time.Now()
+	tr.Result = result
+}
+
+func (tr *TestRun) AddDetails(details string) {
+	tr.Details += "\n        " + details + "\n"
+}
+
+func (tr *TestRun) Error(errorDetails string) {
+	tr.End("ERROR")
+	tr.AddDetails(errorDetails)
+}
+
+func (tr *TestRun) Fail(failureDetails string) {
+	tr.End("FAIL")
+	tr.AddDetails(failureDetails)
+}
+
+/* Print out information about the test run in "go test" output format */
+func (tr *TestRun) Print(writer io.Writer) error {
+	elapsed := tr.EndTime.Sub(tr.StartTime)
+	_, err := fmt.Fprintf(writer, "=== RUN %v\n", tr.TestCaseName)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(writer, "--- %v: %v (%f seconds)\n", tr.Result, tr.TestCaseName, elapsed.Seconds())
+	if tr.Details != "" {
+		_, err = fmt.Fprintf(writer, "			%v\n", tr.Details)
+	}
+	return err
+}


### PR DESCRIPTION
*  send "anonymousId", "context" and "integration" to the program under test
* add support for "screen" and "alias" message types
* output test results to file (in "go test" output format, which can be turned into JUnit XML format using `go-junit-report`)