### PR TITLE
fix DeepEqual check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,57 +2,82 @@
 
 
 [[projects]]
+  digest = "1:7f89e0c888fb99c61055c646f5678aae645b0b0a1443d9b2dcd9964d850827ce"
+  name = "github.com/go-test/deep"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6592d9cc0a499ad2d5f574fde80a2b5c5cc3b4f5"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
+  digest = "1:06d94e582555f421565b117d324d2098f9e666a0bccf545bfb4eb0cc6bdc1b6e"
   name = "github.com/kr/pretty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "cfb55aafdaf3ec08f0db22699ab822c50091b1c4"
 
 [[projects]]
   branch = "master"
+  digest = "1:d249ec295344198f1d3cb3534dc03204a83f7321b99fa604284e4eec1792ddf5"
   name = "github.com/kr/text"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7cafcd837844e784b526369c9bce262804aebc60"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:ec22607298efbafb122c4e4b2ca8ceb6c4ec1ba72e74705b84f9f2ce8ee77984"
   name = "github.com/segmentio/backo-go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "204274ad699c0983a70203a566887f17a717fef4"
 
 [[projects]]
   branch = "master"
+  digest = "1:01ede0b903d4e47d4ebb2fdb14aa6bff755bf4d92858eb4656201324e06aea5f"
   name = "github.com/segmentio/conf"
   packages = ["."]
+  pruneopts = "UT"
   revision = "37796b9487623cab86bf7adb8dff473b8a4f65d9"
 
 [[projects]]
+  digest = "1:45e4eb09df46510fa90ec112d05507d36b6350a297936f76d9205cb0ecea9a67"
   name = "github.com/segmentio/events"
   packages = [
     ".",
-    "text"
+    "text",
   ]
+  pruneopts = "UT"
   revision = "406fcabaf3d3a8c0d790b3bbf7e3f795e277124e"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:338c877d3e0136603b78a7c852cd120422e5787c6c2c5f338230ba2d9771af8f"
   name = "github.com/segmentio/go-snakecase"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3ecf343f213326f182b8477c337a2be66c9205b0"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:8a3e7525dc0cf0236b163166800ecbc78d6c8c5d7ac956996e7b3bef8cfadc41"
   name = "github.com/segmentio/ksuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "112f929a3020abfcd06b77c963ec919130796a35"
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:56a84a380d547f4147fc55203383a565785c57ba3b212697ae3a636db70f0eb8"
   name = "github.com/segmentio/objconv"
   packages = [
     ".",
@@ -62,35 +87,51 @@
     "adapters/net/url",
     "json",
     "objutil",
-    "yaml"
+    "yaml",
   ]
+  pruneopts = "UT"
   revision = "8998c9cea5fb978cf489f7a8ad69159aa7be3d50"
   version = "0.1.0"
 
 [[projects]]
+  digest = "1:dad6cd59e8bb8d209194efbd3850b5d054384a63061671bfc2a6b2cc0929c731"
   name = "gopkg.in/go-playground/mold.v2"
   packages = [
     ".",
-    "modifiers"
+    "modifiers",
   ]
+  pruneopts = "UT"
   revision = "6bc20ce40733e8e04c2fda4523a957dd8e198948"
   version = "v2.2.0"
 
 [[projects]]
   branch = "v2"
+  digest = "1:952adf11fb5bc868cb9d242af59dc4cbafcc8553efddd2124711c0aeb58df2b3"
   name = "gopkg.in/validator.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "59c90c7046f643cbe0d4e7c8776c42a84ce75910"
 
 [[projects]]
+  digest = "1:2a81c6e126d36ad027328cffaa4888fc3be40f09dc48028d1f93705b718130b9"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
   version = "v2.1.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b4ac8d52de1e383fc6e1f0a813196b368c25b954e123549f2c276e0c72711aa2"
+  input-imports = [
+    "github.com/go-test/deep",
+    "github.com/kr/pretty",
+    "github.com/pkg/errors",
+    "github.com/segmentio/backo-go",
+    "github.com/segmentio/conf",
+    "github.com/segmentio/events",
+    "github.com/segmentio/events/text",
+    "github.com/segmentio/ksuid",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/checker.go
+++ b/checker.go
@@ -1,26 +1,21 @@
 package tester
 
 import (
-	"reflect"
-	"unsafe"
+	"github.com/go-test/deep"
 )
 
-// SegmentEqual returns true if the two Segment messages can be considered the
-// same.
+// SegmentEqual returns true if the two Segment messages can be considered the same.
 func SegmentEqual(a, b map[string]interface{}) bool {
-	a = cleanMsg(a)
-	b = cleanMsg(b)
-
-	return DeepEqual(a, b)
+	return deep.Equal(cleanMsg(a), cleanMsg(b)) == nil
 }
 
-func cleanMsg(a map[string]interface{}) map[string]interface{} {
+func cleanMsg(m map[string]interface{}) map[string]interface{} {
 	ignoredKeys := []string{"messageId", "timestamp", "receivedAt", "sentAt", "originalTimestamp", "channel", "version", "projectId", "writeKey"}
-	a = delete(a, ignoredKeys...)
-	if _, ok := a["context"].(map[string]interface{}); ok {
-		a["context"] = delete(a["context"].(map[string]interface{}), "library")
+	m = delete(m, ignoredKeys...)
+	if _, ok := m["context"].(map[string]interface{}); ok {
+		m["context"] = delete(m["context"].(map[string]interface{}), "library")
 	}
-	return a
+	return m
 }
 
 // delete returns a copy of the input map with the given keys deleted.
@@ -39,207 +34,4 @@ func delete(m map[string]interface{}, keys ...string) map[string]interface{} {
 		}
 	}
 	return out
-}
-
-// During deepValueEqual, must keep track of checks that are
-// in progress. The comparison algorithm assumes that all
-// checks in progress are true when it reencounters them.
-// Visited comparisons are stored in a map indexed by visit.
-type visit struct {
-	a1  unsafe.Pointer
-	a2  unsafe.Pointer
-	typ reflect.Type
-}
-
-// Tests for deep equality using reflected types. The map argument tracks
-// comparisons that have already been seen, which allows short circuiting on
-// recursive types.
-func deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool, depth int) bool {
-	if !v1.IsValid() || !v2.IsValid() {
-		return v1.IsValid() == v2.IsValid()
-	}
-	if v1.Type() != v2.Type() {
-		return false
-	}
-
-	// if depth > 10 { panic("deepValueEqual") }	// for debugging
-
-	// We want to avoid putting more in the visited map than we need to.
-	// For any possible reference cycle that might be encountered,
-	// hard(t) needs to return true for at least one of the types in the cycle.
-	hard := func(k reflect.Kind) bool {
-		switch k {
-		case reflect.Map, reflect.Slice, reflect.Ptr, reflect.Interface:
-			return true
-		}
-		return false
-	}
-
-	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
-		addr1 := unsafe.Pointer(v1.UnsafeAddr())
-		addr2 := unsafe.Pointer(v2.UnsafeAddr())
-		if uintptr(addr1) > uintptr(addr2) {
-			// Canonicalize order to reduce number of entries in visited.
-			// Assumes non-moving garbage collector.
-			addr1, addr2 = addr2, addr1
-		}
-
-		// Short circuit if references are already seen.
-		typ := v1.Type()
-		v := visit{addr1, addr2, typ}
-		if visited[v] {
-			return true
-		}
-
-		// Remember for later.
-		visited[v] = true
-	}
-
-	switch v1.Kind() {
-	case reflect.Array:
-		if isNilOrEmpty(v1) == isNilOrEmpty(v2) {
-			return true
-		}
-		for i := 0; i < v1.Len(); i++ {
-			if !deepValueEqual(v1.Index(i), v2.Index(i), visited, depth+1) {
-				return false
-			}
-		}
-		return true
-	case reflect.Slice:
-		if v1.IsNil() != v2.IsNil() {
-			return false
-		}
-		if v1.Len() != v2.Len() {
-			return false
-		}
-		if v1.Pointer() == v2.Pointer() {
-			return true
-		}
-		for i := 0; i < v1.Len(); i++ {
-			if !deepValueEqual(v1.Index(i), v2.Index(i), visited, depth+1) {
-				return false
-			}
-		}
-		return true
-	case reflect.Interface:
-		if v1.IsNil() || v2.IsNil() {
-			return v1.IsNil() == v2.IsNil()
-		}
-		return deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
-	case reflect.Ptr:
-		if v1.Pointer() == v2.Pointer() {
-			return true
-		}
-		return deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
-	case reflect.Struct:
-		for i, n := 0, v1.NumField(); i < n; i++ {
-			if !deepValueEqual(v1.Field(i), v2.Field(i), visited, depth+1) {
-				return false
-			}
-		}
-		return true
-	case reflect.Map:
-		if isNilOrEmpty(v1) == isNilOrEmpty(v2) {
-			return true
-		}
-		if v1.IsNil() != v2.IsNil() {
-			return false
-		}
-		if v1.Len() != v2.Len() {
-			return false
-		}
-		if v1.Pointer() == v2.Pointer() {
-			return true
-		}
-		for _, k := range v1.MapKeys() {
-			val1 := v1.MapIndex(k)
-			val2 := v2.MapIndex(k)
-			if !val1.IsValid() || !val2.IsValid() || !deepValueEqual(v1.MapIndex(k), v2.MapIndex(k), visited, depth+1) {
-				return false
-			}
-		}
-		return true
-	case reflect.Func:
-		if v1.IsNil() && v2.IsNil() {
-			return true
-		}
-		// Can't do better than this:
-		return false
-	case reflect.String:
-		if isNilOrEmpty(v1) == isNilOrEmpty(v2) {
-			return true
-		}
-		return v1.Interface() == v2.Interface()
-	default:
-		// Normal equality suffices
-		return v1.Interface() == v2.Interface()
-	}
-}
-
-func isNilOrEmpty(v reflect.Value) bool {
-	return v.IsNil() || v.Len() == 0
-}
-
-// DeepEqual reports whether x and y are ``deeply equal,'' defined as follows.
-// Two values of identical type are deeply equal if one of the following cases applies.
-// Values of distinct types are never deeply equal.
-//
-// Array values are deeply equal when their corresponding elements are deeply equal.
-//
-// Struct values are deeply equal if their corresponding fields,
-// both exported and unexported, are deeply equal.
-//
-// Func values are deeply equal if both are nil; otherwise they are not deeply equal.
-//
-// Interface values are deeply equal if they hold deeply equal concrete values.
-//
-// Map values are deeply equal when all of the following are true:
-// they are both nil or both non-nil, they have the same length,
-// and either they are the same map object or their corresponding keys
-// (matched using Go equality) map to deeply equal values.
-//
-// Pointer values are deeply equal if they are equal using Go's == operator
-// or if they point to deeply equal values.
-//
-// Slice values are deeply equal when all of the following are true:
-// they are both nil or both non-nil, they have the same length,
-// and either they point to the same initial entry of the same underlying array
-// (that is, &x[0] == &y[0]) or their corresponding elements (up to length) are deeply equal.
-// Note that a non-nil empty slice and a nil slice (for example, []byte{} and []byte(nil))
-// are not deeply equal.
-//
-// Other values - numbers, bools, strings, and channels - are deeply equal
-// if they are equal using Go's == operator.
-//
-// In general DeepEqual is a recursive relaxation of Go's == operator.
-// However, this idea is impossible to implement without some inconsistency.
-// Specifically, it is possible for a value to be unequal to itself,
-// either because it is of func type (uncomparable in general)
-// or because it is a floating-point NaN value (not equal to itself in floating-point comparison),
-// or because it is an array, struct, or interface containing
-// such a value.
-// On the other hand, pointer values are always equal to themselves,
-// even if they point at or contain such problematic values,
-// because they compare equal using Go's == operator, and that
-// is a sufficient condition to be deeply equal, regardless of content.
-// DeepEqual has been defined so that the same short-cut applies
-// to slices and maps: if x and y are the same slice or the same map,
-// they are deeply equal regardless of content.
-//
-// As DeepEqual traverses the data values it may find a cycle. The
-// second and subsequent times that DeepEqual compares two pointer
-// values that have been compared before, it treats the values as
-// equal rather than examining the values to which they point.
-// This ensures that DeepEqual terminates.
-func DeepEqual(x, y interface{}) bool {
-	if x == nil || y == nil {
-		return x == y
-	}
-	v1 := reflect.ValueOf(x)
-	v2 := reflect.ValueOf(y)
-	if v1.Type() != v2.Type() {
-		return false
-	}
-	return deepValueEqual(v1, v2, make(map[visit]bool), 0)
 }

--- a/checker_test.go
+++ b/checker_test.go
@@ -1,0 +1,101 @@
+package tester
+
+import (
+	"testing"
+)
+
+func TestSegmentEqual(t *testing.T) {
+	testCases := []struct {
+		Name  string
+		A     map[string]interface{}
+		B     map[string]interface{}
+		Equal bool
+	}{
+		{
+			Name: "ignored fields can differ",
+			A: map[string]interface{}{
+				"messageId":         "x",
+				"timestamp":         "x",
+				"receivedAt":        "x",
+				"sentAt":            "x",
+				"originalTimestamp": "x",
+				"channel":           "x",
+				"version":           "x",
+				"projectId":         "x",
+				"writeKey":          "x",
+				"context": map[string]interface{}{
+					"library": "x",
+				},
+			},
+			B: map[string]interface{}{
+				"messageId":         "y",
+				"timestamp":         "y",
+				"receivedAt":        "y",
+				"sentAt":            "y",
+				"originalTimestamp": "y",
+				"channel":           "y",
+				"version":           "y",
+				"projectId":         "y",
+				"writeKey":          "y",
+				"context": map[string]interface{}{
+					"library": "y",
+				},
+			},
+			Equal: true,
+		},
+		{
+			Name: ".context should not differ",
+			A: map[string]interface{}{
+				"context": map[string]interface{}{
+					"language": "English",
+				},
+			},
+			B: map[string]interface{}{
+				"context": map[string]interface{}{
+					"language": "English",
+					"location": "US",
+				},
+			},
+			Equal: false,
+		},
+		{
+			Name: ".context can differ by library",
+			A: map[string]interface{}{
+				"context": map[string]interface{}{
+					"language": "English",
+					"library":  "x",
+				},
+			},
+			B: map[string]interface{}{
+				"context": map[string]interface{}{
+					"language": "English",
+					"library":  "y",
+				},
+			},
+			Equal: true,
+		},
+		{
+			Name: ".integrations cannot differ",
+			A: map[string]interface{}{
+				"integrations": map[string]interface{}{
+					"Amplitude": true,
+				},
+			},
+			B: map[string]interface{}{
+				"integrations": map[string]interface{}{
+					"Amplitude": false,
+				},
+			},
+			Equal: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			equal := SegmentEqual(tc.A, tc.B)
+			if equal != tc.Equal {
+				t.Errorf("Expected equality %v but was %v: \nA: %+v\nB: %+v\n", tc.Equal, equal, tc.A, tc.B)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The previous deepEqual check would incorrectly consider the following messages to be the equal:

```
{context: { language: "English" }}
```

```
{context: { language: "Japanese" }}
```

I wasn't sure where the issue was, but instead of writing the equality code ourselves I replaced it with a library.
