### PR TITLE
Fix SegmentEqual: empty fields are equivalent to non-existent

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -2,6 +2,7 @@ package tester
 
 import (
 	"github.com/go-test/deep"
+	"reflect"
 )
 
 // SegmentEqual returns true if the two Segment messages can be considered the same.
@@ -14,6 +15,23 @@ func cleanMsg(m map[string]interface{}) map[string]interface{} {
 	m = delete(m, ignoredKeys...)
 	if _, ok := m["context"].(map[string]interface{}); ok {
 		m["context"] = delete(m["context"].(map[string]interface{}), "library")
+	}
+	// delete empty fields
+	for k, v := range m {
+		if reflect.TypeOf(v).String() == "string" {
+			if len(v.(string)) == 0 {
+				m = delete(m, k)
+			}
+		} else {
+			// not string, check if empty interface
+			empty := true
+			for _ = range v.(map[string]interface{}) {
+				empty = false
+			}
+			if empty {
+				m = delete(m, k)
+			}
+		}
 	}
 	return m
 }

--- a/checker.go
+++ b/checker.go
@@ -2,7 +2,6 @@ package tester
 
 import (
 	"github.com/go-test/deep"
-	"reflect"
 )
 
 // SegmentEqual returns true if the two Segment messages can be considered the same.
@@ -18,10 +17,10 @@ func cleanMsg(m map[string]interface{}) map[string]interface{} {
 	}
 	// delete empty fields
 	for k, v := range m {
-		if reflect.TypeOf(v).String() != "string" {
-			// not string, check if empty interface
+		field, ok := v.(map[string]interface{})
+		if ok {
 			empty := true
-			for _ = range v.(map[string]interface{}) {
+			for _ = range field {
 				empty = false
 			}
 			if empty {

--- a/checker.go
+++ b/checker.go
@@ -18,11 +18,7 @@ func cleanMsg(m map[string]interface{}) map[string]interface{} {
 	}
 	// delete empty fields
 	for k, v := range m {
-		if reflect.TypeOf(v).String() == "string" {
-			if len(v.(string)) == 0 {
-				m = delete(m, k)
-			}
-		} else {
+		if reflect.TypeOf(v).String() != "string" {
 			// not string, check if empty interface
 			empty := true
 			for _ = range v.(map[string]interface{}) {

--- a/checker_test.go
+++ b/checker_test.go
@@ -88,6 +88,18 @@ func TestSegmentEqual(t *testing.T) {
 			},
 			Equal: false,
 		},
+		{
+			Name: "empty values are equivalent to non-existent",
+			A: map[string]interface{}{
+				"type":         "track",
+				"integrations": map[string]interface{}{},
+				"context":      map[string]interface{}{},
+			},
+			B: map[string]interface{}{
+				"type": "track",
+			},
+			Equal: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This fails some tests: when the library add `context/library` to the message, then we remove `library` in `cleanMsg`, then `context` remains (as an empty map) in the message. When we check this again the fixture, which doesn't contain `context`, the 2 messages are considered not equal.