### PR TITLE
Allow parallel execution

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  branch = "master"
+  digest = "1:f6e0b68bce781e6ae4f288ae3a96e94ae9278b7aa658bf9ca8aeab8732ee7658"
+  name = "github.com/f2prateek/semaphore"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "407301f194ce6f9cf4da7c3e3e2b3cfcd2d83bfa"
+
+[[projects]]
   digest = "1:7f89e0c888fb99c61055c646f5678aae645b0b0a1443d9b2dcd9964d850827ce"
   name = "github.com/go-test/deep"
   packages = ["."]
@@ -116,6 +124,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/f2prateek/semaphore",
     "github.com/go-test/deep",
     "github.com/kr/pretty",
     "github.com/pkg/errors",

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -15,17 +15,19 @@ import (
 // Config represents the options that can be supplied to the harness.
 type Config struct {
 	Path                string        `conf:"path"                     help:"path to the library binary" validate:"nonzero"`
-	SegmentWriteKey     string        `conf:"segment-write-key"        help:"writekey for the Segment project to send data to" validate:"nonzero"`
+	SegmentWriteKey     string        `conf:"segment-write-key"        help:"write key for the Segment project to send data to" validate:"nonzero"`
 	WebhookBucket       string        `conf:"webhook-bucket"           help:"webhook bucket the Segment project sends data to" validate:"nonzero"`
 	WebhookAuthUsername string        `conf:"webhook-auth-username"    help:"basic auth username for the webhook bucket the Segment project sends data to" validate:"nonzero"`
-	SkipFixtures        string        `conf:"skip-fixtures"            help:"comma-separated list of fixtures to skip"`
-	Timeout             time.Duration `conf:"timeout"                  help:"Timeout before giving up checking on a message"`
-	Debug               bool          `conf:"debug"                    help:"Enable Debugging"`
+	SkipFixtures        string        `conf:"skip-fixtures"            help:"skip fixtures matching the regex"`
+	Timeout             time.Duration `conf:"timeout"                  help:"if a message does not appear in the webhook within this duration, give up. the default is 5 minutes."`
+	Debug               bool          `conf:"debug"                    help:"enable debug logging"`
+	Concurrency         int           `conf:"concurrency"              help:"allow upto n concurrent tests to run simultaneously. the default is to run 1 test at a time."`
 }
 
 func main() {
 	config := Config{
-		Timeout: 5 * time.Minute,
+		Timeout:     5 * time.Minute,
+		Concurrency: 1,
 	}
 	conf.Load(&config)
 
@@ -40,6 +42,7 @@ func main() {
 		Output:              os.Stdout,
 		SkipFixtures:        splitStringList(config.SkipFixtures),
 		Timeout:             config.Timeout,
+		Concurrency:         config.Concurrency,
 	}
 
 	err := t.Test(invoker)


### PR DESCRIPTION
Allows parallel execution of tests by specifying a concurrency flag. By default 1 test is run at a time.